### PR TITLE
Update docker-compose to use the latest cyhy-mailer Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.0.9'
+    image: 'dhsncats/cyhy-mailer:1.0.10'
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
I forgot to do this in #35.