### PR TITLE
Use latest cyhy-mailer docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.2.3'
+    image: 'dhsncats/cyhy-mailer:1.2.4'
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
I forgot to increment the `cyhy-mailer` version number within `docker-compose.yml` in #52, so this PR fixes that.