### PR TITLE
Use persistent notification volume

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -5,7 +5,7 @@ services:
   mailer:
     volumes:
       - type: bind
-        source: /var/cyhy/notifications/output/archive/latest
+        source: /var/cyhy/reports/output/notification_archive/latest
         target: /cyhy_notifications
     command:
       - report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.2.4'
+    image: 'dhsncats/cyhy-mailer:1.2.5'
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
With the latest change to cyhy-reports, notification PDFs will now be created on a persistent volume.  This PR gives cyhy-mailer the correct path to the latest notifications on that volume.