### PR TITLE
Add cyhy_reports@hq.dhs.gov address

### DIFF
--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -29,7 +29,7 @@ class CybexMessage(ReportMessage):
 
     """
 
-    DefaultTo = ["ncats@hq.dhs.gov"]
+    DefaultTo = ["ncats@hq.dhs.gov", "cyhy_reports@hq.dhs.gov"]
 
     Subject = "Cyber Exposure Scorecard - {{report_date}} Results"
 

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/docker-compose.bod.yml
+++ b/docker-compose.bod.yml
@@ -17,5 +17,5 @@ services:
       - --tmail-report-dir=/trustymail_reports/
       - --https-report-dir=/pshtt_reports/
       - --db-creds-file=/run/secrets/database_creds.yml
-      - "--summary-to=ncats@hq.dhs.gov,jeremy.frasier@trio.dhs.gov,\
-      ncats-dev@beta.dhs.gov"
+      - "--summary-to=ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov,
+      jeremy.frasier@trio.dhs.gov,ncats-dev@beta.dhs.gov"

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -11,4 +11,5 @@ services:
       - report
       - --cyhy-notification-dir=/cyhy_notifications/
       - --db-creds-file=/run/secrets/database_creds.yml
-      - "--summary-to=ncats@hq.dhs.gov,ncats-dev@beta.dhs.gov"
+      - "--summary-to=ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov,\
+      ncats-dev@beta.dhs.gov"

--- a/docker-compose.cyhy.yml
+++ b/docker-compose.cyhy.yml
@@ -15,5 +15,5 @@ services:
       - --cyhy-report-dir=/cyhy_reports/
       - --cybex-scorecard-dir=/cybex_scorecard/
       - --db-creds-file=/run/secrets/database_creds.yml
-      - "--summary-to=ncats@hq.dhs.gov,jeremy.frasier@trio.dhs.gov,\
-      ncats-dev@beta.dhs.gov"
+      - "--summary-to=ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov,\
+      jeremy.frasier@trio.dhs.gov,ncats-dev@beta.dhs.gov"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.2.5'
+    image: 'dhsncats/cyhy-mailer:1.2.7'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cybexmessage.py
+++ b/tests/test_cybexmessage.py
@@ -21,7 +21,7 @@ class Test(unittest.TestCase):
             message["Subject"], "Cyber Exposure Scorecard - December 15, 2001 Results"
         )
         self.assertEqual(message["CC"], None)
-        self.assertEqual(message["To"], "ncats@hq.dhs.gov")
+        self.assertEqual(message["To"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
 
         # Grab the bytes that comprise the attachments
         pdf_bytes = open(pdf, "rb").read()


### PR DESCRIPTION
The CyHy group says that sometimes the CybEx report gets misplaced before they see it on Monday morning.  As a result they asked me to send the CybEx report to `cyhy_reports@hq.dhs.gov`, which is a mailing list they have set up.

I went ahead and made the changes to also send the notification emails to the same address.