### PR TITLE
Fix a typo in a MongoDB query

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -204,7 +204,7 @@ def get_cyhy_and_bod_requests(db, batch_size):
     """
     try:
         requests = db.requests.find(
-            {"retired": {"$ne": True}, "report_types": {"$in", ["CYHY", "BOD"]}},
+            {"retired": {"$ne": True}, "report_types": {"$in": ["CYHY", "BOD"]}},
             {
                 "_id": True,
                 "agency.acronym": True,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.2.7'
+    image: 'dhsncats/cyhy-mailer:1.2.8'
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
This change (1.2.6) somehow never got deployed, but it was rolled into the 1.2.7 update that I manually installed and ran this morning when I sent the reports.  It caused the report sending to fail, so I'm correcting it now.

The reports were still sent this morning using version 1.2.5.