### PR TITLE
CC and BCC shuffle

### DIFF
--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -82,6 +82,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         to_addrs=DefaultTo,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -122,6 +123,10 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         # This is the data mustache will use to render the templates
         mustache_data = {"report_date": report_date}
@@ -140,6 +145,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             pdf_filename,
             from_addr,
             cc_addrs,
+            bcc_addrs,
         )
 
         self.attach_csv(critical_open_csv_filename)

--- a/cyhy/mailer/CyhyMessage.py
+++ b/cyhy/mailer/CyhyMessage.py
@@ -72,6 +72,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -100,6 +101,10 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         # This is the data mustache will use to render the templates
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
@@ -118,4 +123,5 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             pdf_filename,
             from_addr,
             cc_addrs,
+            bcc_addrs,
         )

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -72,6 +72,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -100,6 +101,10 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         # This is the data mustache will use to render the templates
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
@@ -118,4 +123,5 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             pdf_filename,
             from_addr,
             cc_addrs,
+            bcc_addrs,
         )

--- a/cyhy/mailer/HttpsMessage.py
+++ b/cyhy/mailer/HttpsMessage.py
@@ -102,6 +102,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -131,6 +132,10 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         # This is the data mustache will use to render the templates
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
@@ -149,4 +154,5 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             pdf_filename,
             from_addr,
             cc_addrs,
+            bcc_addrs,
         )

--- a/cyhy/mailer/Message.py
+++ b/cyhy/mailer/Message.py
@@ -21,6 +21,10 @@ class Message(MIMEMultipart):
         The default value for the CC addresses to which the message
         should be sent.
 
+    DefaultBcc : list of str
+        The default value for the BCC addresses to which the message
+        should be sent.
+
     DefaultReplyTo : str
         The default value for the address to which replies should be
         directed.
@@ -29,7 +33,9 @@ class Message(MIMEMultipart):
 
     DefaultFrom = "reports@cyber.dhs.gov"
 
-    DefaultCc = ["ncats@hq.dhs.gov", "cyhy_reports@hq.dhs.gov"]
+    DefaultCc = None
+
+    DefaultBcc = ["cyhy_reports@hq.dhs.gov"]
 
     DefaultReplyTo = "ncats@hq.dhs.gov"
 
@@ -41,6 +47,7 @@ class Message(MIMEMultipart):
         html_body=None,
         from_addr=DefaultFrom,
         cc_addrs=DefaultCc,
+        bcc_addrs=DefaultBcc,
         reply_to_addr=DefaultReplyTo,
     ):
         """Construct an instance.
@@ -67,6 +74,10 @@ class Message(MIMEMultipart):
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         reply_to_addr : str
             The email address to which replies should be sent.
 
@@ -82,6 +93,10 @@ class Message(MIMEMultipart):
         if cc_addrs:
             self["CC"] = ",".join(cc_addrs)
             logging.debug("Message to be sent as CC to: %s", self["CC"])
+
+        if bcc_addrs:
+            self["BCC"] = ",".join(bcc_addrs)
+            logging.debug("Message to be sent as BCC to: %s", self["BCC"])
 
         if reply_to_addr:
             self["Reply-To"] = reply_to_addr

--- a/cyhy/mailer/ReportMessage.py
+++ b/cyhy/mailer/ReportMessage.py
@@ -15,6 +15,7 @@ class ReportMessage(Message):
         pdf_filename,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -44,9 +45,20 @@ class ReportMessage(Message):
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         Message.__init__(
-            self, to_addrs, subject, text_body, html_body, from_addr, cc_addrs
+            self,
+            to_addrs,
+            subject,
+            text_body,
+            html_body,
+            from_addr,
+            cc_addrs,
+            bcc_addrs,
         )
 
         self.attach_pdf(pdf_filename)

--- a/cyhy/mailer/TmailMessage.py
+++ b/cyhy/mailer/TmailMessage.py
@@ -100,6 +100,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
+        bcc_addrs=Message.DefaultBcc,
     ):
         """Construct an instance.
 
@@ -129,6 +130,10 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             An array of string objects, each of which is a CC email
             address to which this message should be sent.
 
+        bcc_addrs : array of str
+            An array of string objects, each of which is a BCC email
+            address to which this message should be sent.
+
         """
         # This is the data mustache will use to render the templates
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
@@ -147,4 +152,5 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             pdf_filename,
             from_addr,
             cc_addrs,
+            bcc_addrs,
         )

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.0'
+    image: 'dhsncats/cyhy-mailer:1.3.1'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cybexmessage.py
+++ b/tests/test_cybexmessage.py
@@ -20,7 +20,8 @@ class Test(unittest.TestCase):
         self.assertEqual(
             message["Subject"], "Cyber Exposure Scorecard - December 15, 2001 Results"
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "ncats@hq.dhs.gov")
 
         # Grab the bytes that comprise the attachments
@@ -84,10 +85,20 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         csv = "./tests/data/csv-sample.csv"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         report_date = "December 15, 2001"
 
         message = CybexMessage(
-            pdf, csv, csv, csv, csv, report_date, to_addrs=to, from_addr=fm, cc_addrs=cc
+            pdf,
+            csv,
+            csv,
+            csv,
+            csv,
+            report_date,
+            to_addrs=to,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -95,6 +106,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             message["Subject"], "Cyber Exposure Scorecard - December 15, 2001 Results"
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachments

--- a/tests/test_cyhymessage.py
+++ b/tests/test_cyhymessage.py
@@ -22,7 +22,8 @@ class Test(unittest.TestCase):
             message["Subject"],
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -88,7 +89,8 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             message["Subject"],
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -146,11 +148,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = CyhyMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -159,6 +168,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -216,11 +226,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = CyhyMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -229,6 +246,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -22,7 +22,8 @@ class Test(unittest.TestCase):
             message["Subject"],
             "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -88,7 +89,8 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             message["Subject"],
             "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -146,11 +148,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -159,6 +168,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -216,11 +226,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -229,6 +246,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_httpsmessage.py
+++ b/tests/test_httpsmessage.py
@@ -21,7 +21,8 @@ class Test(unittest.TestCase):
         self.assertEqual(
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -116,7 +117,8 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         self.assertEqual(
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -204,11 +206,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = HttpsMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -216,6 +225,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -303,11 +313,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = HttpsMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -315,6 +332,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -15,7 +15,8 @@ class Test(unittest.TestCase):
         message = Message(to)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
     def test_one_param_multiple_recipients(self):
@@ -25,7 +26,8 @@ class Test(unittest.TestCase):
         message = Message(to)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
     def test_six_params_single_cc(self):
@@ -33,15 +35,19 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com", "recipient2@example.com"]
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
         subject = "The subject"
         text_body = "The plain-text body"
         html_body = "<p>The HTML body</p>"
 
-        message = Message(to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc)
+        message = Message(
+            to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc, bcc_addrs=bcc
+        )
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(message["Subject"], subject)
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Make sure the correct body attachments were added
@@ -57,15 +63,19 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com", "recipient2@example.com"]
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         subject = "The subject"
         text_body = "The plain-text body"
         html_body = "<p>The HTML body</p>"
 
-        message = Message(to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc)
+        message = Message(
+            to, subject, text_body, html_body, from_addr=fm, cc_addrs=cc, bcc_addrs=bcc
+        )
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(message["Subject"], subject)
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Make sure the correct body attachments were added

--- a/tests/test_reportmessage.py
+++ b/tests/test_reportmessage.py
@@ -20,7 +20,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], subject)
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -46,12 +47,14 @@ class Test(unittest.TestCase):
         html_body = "<p>The HTML body</p>"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
 
-        message = ReportMessage(to, subject, text_body, html_body, pdf, fm, cc)
+        message = ReportMessage(to, subject, text_body, html_body, pdf, fm, cc, bcc)
 
         self.assertEqual(message["From"], "sender@example.com")
         self.assertEqual(message["Subject"], subject)
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_statsmessage.py
+++ b/tests/test_statsmessage.py
@@ -19,7 +19,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], "cyhy-mailer summary from {}".format(date))
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Make sure the correct body and PDF attachments were added
@@ -87,7 +88,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], "cyhy-mailer summary from {}".format(date))
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Make sure the correct body and PDF attachments were added

--- a/tests/test_tmailmessage.py
+++ b/tests/test_tmailmessage.py
@@ -22,7 +22,8 @@ class Test(unittest.TestCase):
             message["Subject"],
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -116,7 +117,8 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             message["Subject"],
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
-        self.assertEqual(message["CC"], "ncats@hq.dhs.gov,cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -202,11 +204,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = TmailMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -215,6 +224,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
         self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -300,11 +310,18 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
         agency_acronym = "CLARKE"
         report_date = "December 15, 2001"
 
         message = TmailMessage(
-            to, pdf, agency_acronym, report_date, from_addr=fm, cc_addrs=cc
+            to,
+            pdf,
+            agency_acronym,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
         )
 
         self.assertEqual(message["From"], fm)
@@ -313,6 +330,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br />
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment


### PR DESCRIPTION
Remove the `ncats_cyhy@hq.dhs.gov` address altogether and move the `ncats_reports@hq.dhs.gov` address to the BCC field.  See NCATS JIRA ticket CYHYDEV-771 for more details.