### PR TITLE
Fix GitHub URLs

### DIFF
--- a/cyhy/mailer/StatsMessage.py
+++ b/cyhy/mailer/StatsMessage.py
@@ -63,7 +63,7 @@ Here is the cyhy-mailer summary from {{date}}:
 <p> Please direct feedback and questions to <a
 href="mailto:ncats-dev@beta.dhs.gov">the NCATS Development Team</a>
 and/or the <a
-href="https://github.com/dhs-ncats/cyhy-mailer">cyhy-mailer GitHub
+href="https://github.com/cisagov/cyhy-mailer">cyhy-mailer GitHub
 project</a>.</p>
 
 <p>

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.4'
+    image: 'dhsncats/cyhy-mailer:1.3.5'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_statsmessage.py
+++ b/tests/test_statsmessage.py
@@ -61,7 +61,7 @@ Here is the cyhy-mailer summary from {}:
 <p> Please direct feedback and questions to <a
 href="mailto:ncats-dev@beta.dhs.gov">the NCATS Development Team</a>
 and/or the <a
-href="https://github.com/dhs-ncats/cyhy-mailer">cyhy-mailer GitHub
+href="https://github.com/cisagov/cyhy-mailer">cyhy-mailer GitHub
 project</a>.</p>
 
 <p>
@@ -132,7 +132,7 @@ Here is the cyhy-mailer summary from {}:
 <p> Please direct feedback and questions to <a
 href="mailto:ncats-dev@beta.dhs.gov">the NCATS Development Team</a>
 and/or the <a
-href="https://github.com/dhs-ncats/cyhy-mailer">cyhy-mailer GitHub
+href="https://github.com/cisagov/cyhy-mailer">cyhy-mailer GitHub
 project</a>.</p>
 
 <p>


### PR DESCRIPTION
Resolve #64 by updating the remaining URLs that still reference the dhs-ncats org to use the cisagov org instead.