### PR TITLE
Daily CyHy Notifications for All Orgs (not just Federal)

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -24,7 +24,7 @@ else
             sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
             mv $tmp_file $VERSION_FILE
             git add $VERSION_FILE
-            git commit -m"Bumping version from $old_version to $new_version"
+            git commit -m"Bump version from $old_version to $new_version"
             git push
             ;;
         finalize)
@@ -34,7 +34,7 @@ else
             sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
             mv $tmp_file $VERSION_FILE
             git add $VERSION_FILE
-            git commit -m"Bumping version from $old_version to $new_version"
+            git commit -m"Bump version from $old_version to $new_version"
             git push
             ;;
         show)

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -59,7 +59,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -29,7 +29,7 @@ class CyhyNotificationMessage(ReportMessage):
 
     TextBody = """Greetings {{acronym}},
 
-Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. {{#is_federal}}As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}} The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -40,7 +40,7 @@ National Cybersecurity Assessments and Technical Services (NCATS)
 Cybersecurity and Infrastructure Security Agency (CISA)
 ncats@hq.dhs.gov
 
-WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
 """
 
     HtmlBody = """<html>
@@ -48,7 +48,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
 <body>
 <p>Greetings {{acronym}},</p>
 
-<p>Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.</p>
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. {{#is_federal}}As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}} The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -59,7 +59,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -69,6 +69,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         to_addrs,
         pdf_filename,
         agency_acronym,
+        is_federal,
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
@@ -90,6 +91,9 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             The acronym used by the agency corresponding to the CYHY
             notification attachment.
 
+        is_federal : bool
+            True if the agency is Federal, otherwise False.
+
         report_date : str
             The date corresponding to the CYHY notification attachment.  We
             have been using dates of the form December 12, 2017.
@@ -107,7 +111,11 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         """
         # This is the data mustache will use to render the templates
-        mustache_data = {"acronym": agency_acronym, "report_date": report_date}
+        mustache_data = {
+            "acronym": agency_acronym,
+            "is_federal": is_federal,
+            "report_date": report_date,
+        }
 
         # Render the templates
         subject = pystache.render(CyhyNotificationMessage.Subject, mustache_data)

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.7'
+    image: 'dhsncats/cyhy-mailer:1.3.8'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -72,7 +72,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -142,7 +142,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -222,7 +222,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -302,7 +302,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -372,7 +372,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -442,7 +442,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -522,7 +522,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
@@ -602,7 +602,7 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid &ldquo;need-to-know&rdquo; without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -8,19 +8,22 @@ from cyhy.mailer.CyhyNotificationMessage import CyhyNotificationMessage
 class Test(unittest.TestCase):
     """The tests for the CyhyNotificationMessage class."""
 
-    def test_four_params_single_recipient(self):
-        """Test the 4-parameter version of the constructor."""
+    def test_four_params_single_recipient_fed(self):
+        """Test the 4-parameter Federal version of the constructor."""
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
-        agency_acronym = "CLARKE"
+        agency_acronym = "FEDTEST"
+        is_federal = True
         report_date = "December 15, 2001"
 
-        message = CyhyNotificationMessage(to, pdf, agency_acronym, report_date)
+        message = CyhyNotificationMessage(
+            to, pdf, agency_acronym, is_federal, report_date
+        )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
             message["Subject"],
-            "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -36,9 +39,9 @@ class Test(unittest.TestCase):
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings CLARKE,
+                text_body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -49,16 +52,16 @@ National Cybersecurity Assessments and Technical Services (NCATS)
 Cybersecurity and Infrastructure Security Agency (CISA)
 ncats@hq.dhs.gov
 
-WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
 """
                 self.assertEqual(part.get_payload(), text_body)
             elif part.get_content_type() == "text/html":
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.</p>
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -69,25 +72,28 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_four_params_multiple_recipients(self):
-        """Test the 4-parameter version of the constructor."""
+    def test_four_params_multiple_recipients_fed(self):
+        """Test the 4-parameter Federal version of the constructor."""
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
-        agency_acronym = "CLARKE"
+        agency_acronym = "FEDTEST"
+        is_federal = True
         report_date = "December 15, 2001"
 
-        message = CyhyNotificationMessage(to, pdf, agency_acronym, report_date)
+        message = CyhyNotificationMessage(
+            to, pdf, agency_acronym, is_federal, report_date
+        )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
             message["Subject"],
-            "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -103,9 +109,9 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -116,16 +122,16 @@ National Cybersecurity Assessments and Technical Services (NCATS)
 Cybersecurity and Infrastructure Security Agency (CISA)
 ncats@hq.dhs.gov
 
-WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
 """
                 self.assertEqual(part.get_payload(), body)
             elif part.get_content_type() == "text/html":
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.</p>
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -136,26 +142,28 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_six_params_single_cc(self):
-        """Test the 6-parameter version of the constructor."""
+    def test_six_params_single_cc_fed(self):
+        """Test the 6-parameter Federal version of the constructor."""
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
-        agency_acronym = "CLARKE"
+        agency_acronym = "FEDTEST"
+        is_federal = True
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
             to,
             pdf,
             agency_acronym,
+            is_federal,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -165,7 +173,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         self.assertEqual(message["From"], fm)
         self.assertEqual(
             message["Subject"],
-            "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com")
@@ -181,9 +189,9 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -194,16 +202,16 @@ National Cybersecurity Assessments and Technical Services (NCATS)
 Cybersecurity and Infrastructure Security Agency (CISA)
 ncats@hq.dhs.gov
 
-WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
 """
                 self.assertEqual(part.get_payload(), body)
             elif part.get_content_type() == "text/html":
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.</p>
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -214,26 +222,28 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """
                 self.assertEqual(part.get_payload(), html_body)
 
-    def test_six_params_multiple_cc(self):
-        """Test the 6-parameter version of the constructor."""
+    def test_six_params_multiple_cc_fed(self):
+        """Test the 6-parameter Federal version of the constructor."""
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         fm = "sender@example.com"
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
-        agency_acronym = "CLARKE"
+        agency_acronym = "FEDTEST"
+        is_federal = True
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
             to,
             pdf,
             agency_acronym,
+            is_federal,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -243,7 +253,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         self.assertEqual(message["From"], fm)
         self.assertEqual(
             message["Subject"],
-            "CLARKE - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
@@ -259,9 +269,9 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -272,16 +282,16 @@ National Cybersecurity Assessments and Technical Services (NCATS)
 Cybersecurity and Infrastructure Security Agency (CISA)
 ncats@hq.dhs.gov
 
-WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
 """
                 self.assertEqual(part.get_payload(), body)
             elif part.get_content_type() == "text/html":
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day indicate potential new critical and/or high vulnerabilities. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. Details are attached. Same password as before.</p>
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -292,7 +302,307 @@ The NCATS team</p>
 Cybersecurity and Infrastructure Security Agency (CISA)<br>
 <a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
 
-<p>WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with CISA policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid 'need-to-know' without prior approval of an authorized CISA official.</p>
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+</body>
+</html>
+"""
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_four_params_single_recipient_nonfed(self):
+        """Test the 4-parameter non-Federal version of the constructor."""
+        to = ["recipient@example.com"]
+        pdf = "./tests/data/pdf-sample.pdf"
+        agency_acronym = "NONFEDTEST"
+        is_federal = False
+        report_date = "December 15, 2001"
+
+        message = CyhyNotificationMessage(
+            to, pdf, agency_acronym, is_federal, report_date
+        )
+
+        self.assertEqual(message["From"], "reports@cyber.dhs.gov")
+        self.assertEqual(
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+        )
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["To"], "recipient@example.com")
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, "rb").read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == "application/pdf":
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), "pdf-sample.pdf")
+            elif part.get_content_type() == "text/plain":
+                text_body = """Greetings NONFEDTEST,
+
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+
+If you have any questions, please contact our office.
+
+Cheers,
+The NCATS team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+Cybersecurity and Infrastructure Security Agency (CISA)
+ncats@hq.dhs.gov
+
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
+"""
+                self.assertEqual(part.get_payload(), text_body)
+            elif part.get_content_type() == "text/html":
+                html_body = """<html>
+<head></head>
+<body>
+<p>Greetings NONFEDTEST,</p>
+
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+
+<p>If you have any questions, please contact our office.</p>
+
+<p>Cheers,<br>
+The NCATS team</p>
+
+<p>National Cybersecurity Assessments and Technical Services (NCATS)<br>
+Cybersecurity and Infrastructure Security Agency (CISA)<br>
+<a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
+
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+</body>
+</html>
+"""
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_four_params_multiple_recipients_nonfed(self):
+        """Test the 4-parameter non-Federal version of the constructor."""
+        to = ["recipient@example.com", "recipient2@example.com"]
+        pdf = "./tests/data/pdf-sample.pdf"
+        agency_acronym = "NONFEDTEST"
+        is_federal = False
+        report_date = "December 15, 2001"
+
+        message = CyhyNotificationMessage(
+            to, pdf, agency_acronym, is_federal, report_date
+        )
+
+        self.assertEqual(message["From"], "reports@cyber.dhs.gov")
+        self.assertEqual(
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+        )
+        self.assertEqual(message.get("CC"), None)
+        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, "rb").read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == "application/pdf":
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), "pdf-sample.pdf")
+            elif part.get_content_type() == "text/plain":
+                body = """Greetings NONFEDTEST,
+
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+
+If you have any questions, please contact our office.
+
+Cheers,
+The NCATS team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+Cybersecurity and Infrastructure Security Agency (CISA)
+ncats@hq.dhs.gov
+
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
+"""
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == "text/html":
+                html_body = """<html>
+<head></head>
+<body>
+<p>Greetings NONFEDTEST,</p>
+
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+
+<p>If you have any questions, please contact our office.</p>
+
+<p>Cheers,<br>
+The NCATS team</p>
+
+<p>National Cybersecurity Assessments and Technical Services (NCATS)<br>
+Cybersecurity and Infrastructure Security Agency (CISA)<br>
+<a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
+
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+</body>
+</html>
+"""
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_single_cc_nonfed(self):
+        """Test the 6-parameter non-Federal version of the constructor."""
+        to = ["recipient@example.com", "recipient2@example.com"]
+        pdf = "./tests/data/pdf-sample.pdf"
+        fm = "sender@example.com"
+        cc = ["cc@example.com"]
+        bcc = ["bcc@example.com"]
+        agency_acronym = "NONFEDTEST"
+        is_federal = False
+        report_date = "December 15, 2001"
+
+        message = CyhyNotificationMessage(
+            to,
+            pdf,
+            agency_acronym,
+            is_federal,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
+        )
+
+        self.assertEqual(message["From"], fm)
+        self.assertEqual(
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+        )
+        self.assertEqual(message["CC"], "cc@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com")
+        self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, "rb").read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == "application/pdf":
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), "pdf-sample.pdf")
+            elif part.get_content_type() == "text/plain":
+                body = """Greetings NONFEDTEST,
+
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+
+If you have any questions, please contact our office.
+
+Cheers,
+The NCATS team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+Cybersecurity and Infrastructure Security Agency (CISA)
+ncats@hq.dhs.gov
+
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
+"""
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == "text/html":
+                html_body = """<html>
+<head></head>
+<body>
+<p>Greetings NONFEDTEST,</p>
+
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+
+<p>If you have any questions, please contact our office.</p>
+
+<p>Cheers,<br>
+The NCATS team</p>
+
+<p>National Cybersecurity Assessments and Technical Services (NCATS)<br>
+Cybersecurity and Infrastructure Security Agency (CISA)<br>
+<a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
+
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
+</body>
+</html>
+"""
+                self.assertEqual(part.get_payload(), html_body)
+
+    def test_six_params_multiple_cc_nonfed(self):
+        """Test the 6-parameter non-Federal version of the constructor."""
+        to = ["recipient@example.com", "recipient2@example.com"]
+        pdf = "./tests/data/pdf-sample.pdf"
+        fm = "sender@example.com"
+        cc = ["cc@example.com", "cc2@example.com"]
+        bcc = ["bcc@example.com", "bcc2@example.com"]
+        agency_acronym = "NONFEDTEST"
+        is_federal = False
+        report_date = "December 15, 2001"
+
+        message = CyhyNotificationMessage(
+            to,
+            pdf,
+            agency_acronym,
+            is_federal,
+            report_date,
+            from_addr=fm,
+            cc_addrs=cc,
+            bcc_addrs=bcc,
+        )
+
+        self.assertEqual(message["From"], fm)
+        self.assertEqual(
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+        )
+        self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
+        self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
+        self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
+
+        # Grab the bytes that comprise the attachment
+        bytes = open(pdf, "rb").read()
+
+        # Make sure the correct body and PDF attachments were added
+        for part in message.walk():
+            # multipart/* are just containers
+            if part.get_content_type() == "application/pdf":
+                self.assertEqual(part.get_payload(decode=True), bytes)
+                self.assertEqual(part.get_filename(), "pdf-sample.pdf")
+            elif part.get_content_type() == "text/plain":
+                body = """Greetings NONFEDTEST,
+
+Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+
+If you have any questions, please contact our office.
+
+Cheers,
+The NCATS team
+
+National Cybersecurity Assessments and Technical Services (NCATS)
+Cybersecurity and Infrastructure Security Agency (CISA)
+ncats@hq.dhs.gov
+
+WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.
+"""
+                self.assertEqual(part.get_payload(), body)
+            elif part.get_content_type() == "text/html":
+                html_body = """<html>
+<head></head>
+<body>
+<p>Greetings NONFEDTEST,</p>
+
+<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+
+<p>If you have any questions, please contact our office.</p>
+
+<p>Cheers,<br>
+The NCATS team</p>
+
+<p>National Cybersecurity Assessments and Technical Services (NCATS)<br>
+Cybersecurity and Infrastructure Security Agency (CISA)<br>
+<a href="mailto:ncats@hq.dhs.gov">ncats@hq.dhs.gov</a></p>
+
+<p>WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOUO). It contains information that may be exempt from public release under the Freedom of Information Act (5 U.S.G. 552). It is to be controlled, stored, handled, transmitted, distributed, and disposed of in accordance with DHS policy relating to FOUO information and is not to be released to the public or other personnel who do not have a valid "need-to-know" without prior approval of an authorized DHS official.</p>
 </body>
 </html>
 """


### PR DESCRIPTION
This PR modifies cyhy-mailer so that it sends out daily notifications to any org that receives CyHy reports.  Previously, this was limited to Federal orgs that were included in the Cyber Exposure Scorecard.

Also included are:
* Changes to the notification email language, provided by the CyHy team (including slightly different language for Federal vs. non-Federal orgs)
* Updated tests for Federal vs. non-Federal
* Small change to the commit message wording in the `bump_version.sh` script