### PR TITLE
Remove default BCC from CyHy report and notification emails

### DIFF
--- a/cyhy/mailer/CyhyMessage.py
+++ b/cyhy/mailer/CyhyMessage.py
@@ -97,7 +97,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         tech_pocs,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
-        bcc_addrs=Message.DefaultBcc,
+        bcc_addrs=None,
     ):
         """Construct an instance.
 

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -73,7 +73,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
-        bcc_addrs=Message.DefaultBcc,
+        bcc_addrs=None,
     ):
         """Construct an instance.
 

--- a/tests/test_cyhymessage.py
+++ b/tests/test_cyhymessage.py
@@ -24,7 +24,7 @@ class Test(unittest.TestCase):
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -95,7 +95,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -186,7 +186,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
             "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -96,7 +96,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -326,7 +326,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -396,7 +396,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment


### PR DESCRIPTION
As requested, this PR removes the default BCC email address from CyHy reports and daily notification emails.  We are awaiting word on whether or not we should do the same thing for HTTPS and Trustymail report emails, so stay tuned.  

Until this is all sorted out, this PR will remain a draft.