### PR TITLE
Send CyHy third-party reports

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -747,7 +747,12 @@ def send_cyhy_reports(db, batch_size, ses_client, cyhy_report_dir):
                 )
             elif not cyhy_report_filenames:
                 # This is an error since we are starting from the list
-                # of CyHy agencys and they should all have reports
+                # of CyHy agencies and they should all have reports
+                #
+                # It is possible to get this error if a CyHy request doc
+                # has "CYHY_THIRD_PARTY" in its report_types, but it does
+                # not have any children (the reporting code skips these
+                # request docs).
                 logging.error(f"No Cyber Hygiene report found for agency with ID {id}")
 
             if cyhy_report_filenames:

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -747,12 +747,12 @@ def send_cyhy_reports(db, batch_size, ses_client, cyhy_report_dir):
                 )
             elif not cyhy_report_filenames:
                 # This is an error since we are starting from the list
-                # of CyHy agencies and they should all have reports
+                # of CyHy agencies and they should all have reports.
                 #
-                # It is possible to get this error if a CyHy request doc
-                # has "CYHY_THIRD_PARTY" in its report_types, but it does
-                # not have any children (the reporting code skips these
-                # request docs).
+                # It is possible to get this error if a CyHy request
+                # doc has "CYHY_THIRD_PARTY" in its report_types, but
+                # it does not have any children (the reporting code
+                # skips these request docs).
                 logging.error(f"No Cyber Hygiene report found for agency with ID {id}")
 
             if cyhy_report_filenames:

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -695,7 +695,9 @@ def send_cyhy_reports(db, batch_size, ses_client, cyhy_report_dir):
 
     """
     try:
-        cyhy_requests = get_requests(db, report_types=["CYHY"], batch_size=batch_size)
+        cyhy_requests = get_requests(
+            db, report_types=["CYHY", "CYHY_THIRD_PARTY"], batch_size=batch_size
+        )
     except TypeError:
         return 4
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.8'
+    image: 'dhsncats/cyhy-mailer:1.3.9'
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
This is a small PR that adds the ability to send out CyHy third-party reports.  It is related to https://github.com/jsf9k/cyhy-reports/pull/40, https://github.com/jsf9k/cyhy-core/pull/35, and [CYHYDEV-780](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-780).