### PR TITLE
Fix Query Projection to Include PoC Names

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -197,6 +197,7 @@ def get_requests_raw(db, query, batch_size=None):
     projection = {
         "_id": True,
         "agency.acronym": True,
+        "agency.contacts.name": True,
         "agency.contacts.email": True,
         "agency.contacts.type": True,
     }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR fixes a bug that resulted in Point of Contact names from being absent in CyHy report emails. The projection used for database queries was missing the name field which resulted in the absence.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The CyHy team alerted us that Point of Contact names were not appearing in CyHy report emails being sent out.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I spun up a test environment and ensured that `cyhy-mailer` CyHy report run would include names in the email body.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
