### PR TITLE
Include "potentially risky services" in CyHy notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these owners will be requested for review when someone
+# opens a pull request.
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v2.5.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.16.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -31,7 +31,7 @@ repos:
         # alone.
         exclude: LICENSE.md
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.15.0
+    rev: v1.22.1
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -39,39 +39,38 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.17.1
+    rev: v2.1.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.0
+    rev: 1.6.2
     hooks:
       - id: bandit
   - repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.0a0
+    rev: v4.3.0a0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.11.0
+    rev: v1.29.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate_no_variables
-      - id: terraform_docs
+      - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.17.1
+    rev: 2.0.4
     hooks:
       - id: prettier

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -25,11 +25,19 @@ class CyhyNotificationMessage(ReportMessage):
 
     """
 
-    Subject = "{{acronym}} - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - {{report_date}}"
+    Subject = "{{acronym}} - Cyber Hygiene Alert - {{report_date}}"
 
     TextBody = """Greetings {{acronym}},
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. {{#is_federal}}As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}} The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+{{#is_federal}}As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}}
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -48,7 +56,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings {{acronym}},</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. {{#is_federal}}As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}} The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>{{#is_federal}}As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.{{/is_federal}}{{^is_federal}}CISA recommends remediating critical findings within 15 days and high findings within 30 days.{{/is_federal}}</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -22,8 +22,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"],
-            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -41,7 +40,15 @@ class Test(unittest.TestCase):
             elif part.get_content_type() == "text/plain":
                 text_body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -61,7 +68,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -92,8 +110,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"],
-            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -111,7 +128,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -131,7 +156,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -172,8 +208,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"],
-            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com")
@@ -191,7 +226,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -211,7 +254,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -252,8 +306,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"],
-            "FEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
@@ -271,7 +324,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings FEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+As part of BOD 19-02, critical findings need to be remediated within 15 days and high findings remediated within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -291,7 +352,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings FEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>As part of <a href="https://cyber.dhs.gov/bod/19-02/">BOD 19-02</a>, critical findings need to be remediated within 15 days and high findings remediated within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -322,8 +394,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"],
-            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -341,7 +412,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 text_body = """Greetings NONFEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+CISA recommends remediating critical findings within 15 days and high findings within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -361,7 +440,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings NONFEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>CISA recommends remediating critical findings within 15 days and high findings within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -392,8 +482,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"],
-            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -411,7 +500,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings NONFEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+CISA recommends remediating critical findings within 15 days and high findings within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -431,7 +528,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings NONFEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>CISA recommends remediating critical findings within 15 days and high findings within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -472,8 +580,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"],
-            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com")
@@ -491,7 +598,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings NONFEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+CISA recommends remediating critical findings within 15 days and high findings within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -511,7 +626,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings NONFEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>CISA recommends remediating critical findings within 15 days and high findings within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 
@@ -552,8 +678,7 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"],
-            "NONFEDTEST - Cyber Hygiene Alert - New Critical/High Vulnerabilities Detected - December 15, 2001",
+            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
@@ -571,7 +696,15 @@ Cybersecurity and Infrastructure Security Agency (CISA)<br>
             elif part.get_content_type() == "text/plain":
                 body = """Greetings NONFEDTEST,
 
-Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
+Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+* New critical and/or high vulnerabilities
+* New potentially risky services
+
+CISA recommends remediating critical findings within 15 days and high findings within 30 days.
+
+CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.
+
+The details are in the attached PDF, which has the same password as your Cyber Hygiene report.
 
 If you have any questions, please contact our office.
 
@@ -591,7 +724,18 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
 <body>
 <p>Greetings NONFEDTEST,</p>
 
-<p>Cyber Hygiene scans conducted in the past day have detected potential new critical and/or high vulnerabilities on one or more of your hosts. CISA recommends remediating critical findings within 15 days and high findings within 30 days. The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
+<p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or both of the following:
+<ul>
+  <li>New critical and/or high vulnerabilities</li>
+  <li>New potentially risky services</li>
+</ul>
+</p>
+
+<p>CISA recommends remediating critical findings within 15 days and high findings within 30 days.</p>
+
+<p>CISA also recommends reviewing hosts with potentially risky open services (e.g. RDP, Telnet, etc.) to ensure that each service is intended to be available to the public and, where applicable, the service is up-to-date on the latest version, correctly configured, and uses strong authentication.</p>
+
+<p>The details are in the attached PDF, which has the same password as your Cyber Hygiene report.</p>
 
 <p>If you have any questions, please contact our office.</p>
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds language related to "potentially risky services" to the (daily) CyHy notification emails.  

Since I was making updates, I also did some housekeeping:
* Updated all of the `pre-commit` hooks for this project by running `pre-commit autoupdate`.
* Added a GitHub `CODEOWNERS` file.

This PR should be deployed at the same time as: https://github.com/jsf9k/cyhy-core/pull/39 and https://github.com/jsf9k/cyhy-reports/pull/48.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The CyHy team wanted to expand the daily notification emails to include the "potentially risky services" that we now [highlight in the weekly CyHy reports](https://github.com/jsf9k/cyhy-reports/pull/41).

See [CYHYDEV-779](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-779) for more information.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All of the automated tests passed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated tests to cover my changes.
- [x] All new and existing tests passed.
