### PR TITLE
Maintenance of docker-compose Configuration Files

### DIFF
--- a/docker-compose.bod.yml
+++ b/docker-compose.bod.yml
@@ -3,6 +3,7 @@ version: '3.2'
 
 services:
   mailer:
+    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: "/var/cyhy/orchestrator/output/archive/latest/reporting/\

--- a/docker-compose.bod.yml
+++ b/docker-compose.bod.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.7'
+version: '3.2'
 
 services:
   mailer:

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.7'
+version: '3.2'
 
 services:
   mailer:

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -3,6 +3,7 @@ version: '3.2'
 
 services:
   mailer:
+    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: /var/cyhy/reports/output/notification_archive/latest

--- a/docker-compose.cyhy.yml
+++ b/docker-compose.cyhy.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.7'
+version: '3.2'
 
 services:
   mailer:

--- a/docker-compose.cyhy.yml
+++ b/docker-compose.cyhy.yml
@@ -3,6 +3,7 @@ version: '3.2'
 
 services:
   mailer:
+    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: /var/cyhy/reports/output/report_archive/latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.7'
+version: '3.1'
 
 secrets:
   database_creds:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 ---
-version: '3.1'
+# The version for the main docker-compose configuration needs to be the lowest
+# version that supports the features used by all docker-compose configurations in
+# this project. This is to support the use of a 'docker-compose.override.yml' file
+# derived from one of the other configurations as documented here:
+# https://docs.docker.com/compose/extends/#multiple-compose-files
+version: '3.2'
 
 secrets:
   database_creds:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR does two things:
1. Update the `version` of the `docker-compose` configuration files to the minimum required version.
2. Make sure all configuration pass `docker-compose --file <filename> config --quiet`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

The first point is a result of the following error message noticed in production:

```console
docker-compose up -d
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```

After discussion, we are updating to use the minimum required version, which I have determined per feature introductions in [the documentation](https://docs.docker.com/compose/compose-file/compose-versioning/#version-3).

The second point is a result of attempting to head off future issues preemptively by making sure they pass a configuration validation. When running the command listed above, the files updated returned the following error:

```console
ERROR: The Compose file is invalid because:
Service mailer has neither an image nor a build context specified. At least one must be provided.
```

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
`pytest` passes locally, `pre-commit` has some grief in unrelated files. I will need to do a PR to merge [cisagov/skeleton-python-library](https://github.com/cisagov/skeleton-python-library) correctly so the automated testing workflows function as expected. This is documented in #80 .
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
