### PR TITLE
Update cybex recipients

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.4.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -31,7 +31,7 @@ repos:
         # alone.
         exclude: LICENSE.md
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.22.1
+    rev: v1.26.1
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -39,38 +39,38 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.1
+    rev: v2.13.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
+    rev: 1.7.0
     hooks:
       - id: bandit
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 21.4b1
     hooks:
       - id: black
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.3.0a0
+    rev: v5.0.7
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.29.0
+    rev: v1.50.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.1
+    rev: v2.0.0
     hooks:
       - id: docker-compose-check
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.4
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 dist: focal
 language: python
-python: 3.7
+python:
+  - "3.8"
+  - "3.9"
 # pre-commit hooks can use Docker, so we should go ahead and enable it
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 dist: focal
 language: python
 python:
+  - "3.7"
   - "3.8"
   - "3.9"
 # pre-commit hooks can use Docker, so we should go ahead and enable it
@@ -45,4 +46,4 @@ deploy:
     script: bash travis_scripts/deploy_to_docker_hub.sh
     on:
       tags: true
-      python: '3.7'
+      python: '3.9'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-dist: xenial
+dist: focal
 language: python
 python: 3.7
 # pre-commit hooks can use Docker, so we should go ahead and enable it

--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -30,9 +30,9 @@ class CybexMessage(ReportMessage):
     """
 
     DefaultTo = [
-        "vulnerability@cisa.dhs.gov",
-        "CyberDirectives@hq.dhs.gov",
-        "CyberLiason@hq.dhs.gov",
+        "CyHy_Reports@hq.dhs.gov",
+        "CyberDirectives@cisa.dhs.gov",
+        "CyberLiaison@cisa.dhs.gov",
     ]
 
     Subject = "Cyber Exposure Scorecard - {{report_date}} Results"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.12"
+__version__ = "1.3.13"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -319,7 +319,7 @@ def send_message(ses_client, message, counter=None):
     # Check for errors
     status_code = response["ResponseMetadata"]["HTTPStatusCode"]
     if status_code != 200:
-        logging.error(f"Unable to send message.  " "Response from boto3 is: {response}")
+        logging.error("Unable to send message.  Response from boto3 is: {response}")
         raise UnableToSendError(response)
 
     if counter is not None:

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -319,7 +319,7 @@ def send_message(ses_client, message, counter=None):
     # Check for errors
     status_code = response["ResponseMetadata"]["HTTPStatusCode"]
     if status_code != 200:
-        logging.error("Unable to send message.  Response from boto3 is: {response}")
+        logging.error(f"Unable to send message.  Response from boto3 is: {response}")
         raise UnableToSendError(response)
 
     if counter is not None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 ---
-# The version for the main docker-compose configuration needs to be the lowest
-# version that supports the features used by all docker-compose configurations in
-# this project. This is to support the use of a 'docker-compose.override.yml' file
-# derived from one of the other configurations as documented here:
+# The version for the main docker-compose configuration needs to be
+# the lowest version that supports the features used by all
+# docker-compose configurations in this project. This is to support
+# the use of a 'docker-compose.override.yml' file derived from one of
+# the other configurations as documented here:
 # https://docs.docker.com/compose/extends/#multiple-compose-files
 version: '3.2'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.12'
+    image: 'dhsncats/cyhy-mailer:1.3.13'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cybexmessage.py
+++ b/tests/test_cybexmessage.py
@@ -24,7 +24,7 @@ class Test(unittest.TestCase):
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(
             message["To"],
-            "vulnerability@cisa.dhs.gov,CyberDirectives@hq.dhs.gov,CyberLiason@hq.dhs.gov",
+            "CyHy_Reports@hq.dhs.gov,CyberDirectives@cisa.dhs.gov,CyberLiaison@cisa.dhs.gov",
         )
 
         # Grab the bytes that comprise the attachments

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -22,7 +22,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -106,7 +107,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -200,7 +202,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com")
@@ -294,7 +297,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"], "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")
@@ -378,7 +382,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -462,7 +467,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
-            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
@@ -556,7 +562,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com")
@@ -650,7 +657,8 @@ Cybersecurity and Infrastructure Security Agency<br>
 
         self.assertEqual(message["From"], fm)
         self.assertEqual(
-            message["Subject"], "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
+            message["Subject"],
+            "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message["CC"], "cc@example.com,cc2@example.com")
         self.assertEqual(message["BCC"], "bcc@example.com,bcc2@example.com")


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the default recipients of the CybEx message type, in accordance with #83.  I also had to make some changes to the TravisCI configuration to get the builds to pass.  The long term solution is to merge in the appropriate skeleton, as described in #80.

## 💭 Motivation and context ##

This pull request addresses #83, which I will resolve manually once we successfully send out reports using these changes.

## 🧪 Testing ##

All `pre-commit` hooks and `pytest` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
