### PR TITLE
Use the latest cyhy-mailer Docker image everywhere

### DIFF
--- a/docker-compose.bod.yml
+++ b/docker-compose.bod.yml
@@ -3,7 +3,6 @@ version: '3.2'
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: "/var/cyhy/orchestrator/output/archive/latest/reporting/\

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -3,7 +3,6 @@ version: '3.2'
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: /var/cyhy/reports/output/notification_archive/latest

--- a/docker-compose.cyhy.yml
+++ b/docker-compose.cyhy.yml
@@ -3,7 +3,6 @@ version: '3.2'
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.12'
     volumes:
       - type: bind
         source: /var/cyhy/reports/output/report_archive/latest


### PR DESCRIPTION
## 🗣 Description ##

This pull request ensures that the latest version of the Docker cyhy-mailer Docker image is used.

## 💭 Motivation and context ##

In PR #84 I updated the cyhy-mailer Docker image version in `docker-compose.yml`, but the change did not take.  I eventually figured out that this was because the `image` key (which was pointing to the previous version of the image) also existed in
`docker-compose.{bod,cyhy-notification,cyhy}.yml`.  To make it so that we only need update the image in a single place, I am removing the redundant `image` key from `docker-compose.{bod,cyhy-notification,cyhy}.yml`.

Thanks to @climber-girl for [noticing the error](https://github.com/cisagov/cyhy-mailer/issues/83#issuecomment-831262929).

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
