### PR TITLE
Remove Lineage Configuration

### DIFF
--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -1,6 +1,0 @@
----
-version: "1"
-
-lineage:
-  skeleton:
-    remote-url: https://github.com/cisagov/skeleton-python-library.git


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the Lineage configuration from this repository.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This project has not been [skeletonized per our guide](https://github.com/cisagov/development-guide/blob/develop/project_setup/skeletonize-existing-repository.md) and #80 remains open. This results in the following error when [cisagov/action-lineage](https://github.com/cisagov/action-lineage) runs against this repository:

```log
INFO Attempting merge of fetched changes.
INFO ✅ (error ok) return code: 128
WARNING Repository lineage is incorrect.  Merge refused.
```

The resolution of #80 will result in a Lineage configuration being re-added to this repository.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Testing? Pardon?
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
