### PR TITLE
Add address to default recipients of CybEx report

### DIFF
--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -33,6 +33,7 @@ class CybexMessage(ReportMessage):
         "CyHy_Reports@hq.dhs.gov",
         "CyberDirectives@cisa.dhs.gov",
         "CyberLiaison@cisa.dhs.gov",
+        "cyberscopehelp@cisa.dhs.gov",
     ]
 
     Subject = "Cyber Exposure Scorecard - {{report_date}} Results"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.13'
+    image: 'dhsncats/cyhy-mailer:1.3.14'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cybexmessage.py
+++ b/tests/test_cybexmessage.py
@@ -24,7 +24,7 @@ class Test(unittest.TestCase):
         self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
         self.assertEqual(
             message["To"],
-            "CyHy_Reports@hq.dhs.gov,CyberDirectives@cisa.dhs.gov,CyberLiaison@cisa.dhs.gov",
+            "CyHy_Reports@hq.dhs.gov,CyberDirectives@cisa.dhs.gov,CyberLiaison@cisa.dhs.gov,cyberscopehelp@cisa.dhs.gov",
         )
 
         # Grab the bytes that comprise the attachments


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an email address to the list of default recipients of the CybEx report.

## 💭 Motivation and context ##

Resolves #88.

## 🧪 Testing ##

All `pre-commit` hooks and `pytest` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
