### PR TITLE
Fix pystache import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 # seem to know how to HTTPS.
 RUN apk --no-cache add openssl shadow wget
 
-# Update pip and setuptools
-RUN pip3 install --upgrade pip setuptools
+# Update pip, setuptools, and wheel
+RUN pip3 install --upgrade pip setuptools wheel
 
 # Install cyhy-mailer
 RUN mkdir cyhy-mailer

--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ pip install git+https://github.com/cisagov/cyhy-mailer.git
 
 ```bash
 Usage:
-  cyhy-mailer report [--cyhy-report-dir=DIRECTORY]
+  cyhy-mailer (bod1801|cybex|cyhy|notification)... [--cyhy-report-dir=DIRECTORY]
 [--tmail-report-dir=DIRECTORY] [--https-report-dir=DIRECTORY]
 [--cybex-scorecard-dir=DIRECTORY] [--cyhy-notification-dir=DIRECTORY]
 [--db-creds-file=FILENAME] [--batch-size=SIZE] [--summary-to=EMAILS] [--debug]
-  cyhy-mailer adhoc --subject=SUBJECT --html-body=FILENAME --text-body=FILENAME
-[--to=EMAILS] [--cyhy] [--cyhy-federal] [--db-creds-file=FILENAME]
-[--batch-size=SIZE] [--summary-to=EMAILS] [--debug]
+[--dry-run]
   cyhy-mailer (-h | --help)
 
 Options:
@@ -66,25 +64,9 @@ Options:
                                     to which the summary statistics should be
                                     sent at the end of the run.  If not
                                     specified then no summary will be sent.
-  -d --debug                        A Boolean value indicating whether the
-                                    output should include debugging messages
-                                    or not.
-  --subject=SUBJECT                 The subject line when sending an ad hoc
-                                    email message.
-  --html-body=FILENAME              The file containing the HTML body text
-                                    when sending an ad hoc email message.
-  --text-body=FILENAME              The file containing the text body text
-                                    when sending an ad hoc email message.
-  --to=EMAILS                       A comma-separated list of additional
-                                    email addresses to which the ad hoc
-                                    message should be sent.
-  --cyhy                            If present, then the ad hoc message
-                                    will be sent to all Cyber Hygiene
-                                    agencies.
-  --cyhy-federal                    If present, then the ad hoc message
-                                    will be sent to all Federal Cyber
-                                    Hygiene agencys.  (Note that --cyhy
-                                    implies --cyhy-federal.)
+  -d --debug                        Include debugging messages in the output.
+  --dry-run                         Do everything except actually send out
+                                    emails.
 ```
 
 ## License ##

--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -1,6 +1,6 @@
 """This module contains the CybexMessage class."""
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 from cyhy.mailer.ReportMessage import ReportMessage
@@ -133,9 +133,9 @@ Cybersecurity and Infrastructure Security Agency<br>
         mustache_data = {"report_date": report_date}
 
         # Render the templates
-        subject = pystache.render(CybexMessage.Subject, mustache_data)
-        text_body = pystache.render(CybexMessage.TextBody, mustache_data)
-        html_body = pystache.render(CybexMessage.HtmlBody, mustache_data)
+        subject = chevron.render(CybexMessage.Subject, mustache_data)
+        text_body = chevron.render(CybexMessage.TextBody, mustache_data)
+        html_body = chevron.render(CybexMessage.HtmlBody, mustache_data)
 
         ReportMessage.__init__(
             self,

--- a/cyhy/mailer/CyhyMessage.py
+++ b/cyhy/mailer/CyhyMessage.py
@@ -1,6 +1,6 @@
 """This module contains the CyhyMessage class."""
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 from cyhy.mailer.ReportMessage import ReportMessage
@@ -144,9 +144,9 @@ Cybersecurity and Infrastructure Security Agency<br>
         }
 
         # Render the templates
-        subject = pystache.render(CyhyMessage.Subject, mustache_data)
-        text_body = pystache.render(CyhyMessage.TextBody, mustache_data)
-        html_body = pystache.render(CyhyMessage.HtmlBody, mustache_data)
+        subject = chevron.render(CyhyMessage.Subject, mustache_data)
+        text_body = chevron.render(CyhyMessage.TextBody, mustache_data)
+        html_body = chevron.render(CyhyMessage.HtmlBody, mustache_data)
 
         ReportMessage.__init__(
             self,

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -1,6 +1,6 @@
 """This module contains the CyhyNotificationMessage class."""
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 from cyhy.mailer.ReportMessage import ReportMessage
@@ -133,9 +133,9 @@ Cybersecurity and Infrastructure Security Agency<br>
         }
 
         # Render the templates
-        subject = pystache.render(CyhyNotificationMessage.Subject, mustache_data)
-        text_body = pystache.render(CyhyNotificationMessage.TextBody, mustache_data)
-        html_body = pystache.render(CyhyNotificationMessage.HtmlBody, mustache_data)
+        subject = chevron.render(CyhyNotificationMessage.Subject, mustache_data)
+        text_body = chevron.render(CyhyNotificationMessage.TextBody, mustache_data)
+        html_body = chevron.render(CyhyNotificationMessage.HtmlBody, mustache_data)
 
         ReportMessage.__init__(
             self,

--- a/cyhy/mailer/HttpsMessage.py
+++ b/cyhy/mailer/HttpsMessage.py
@@ -1,6 +1,6 @@
 """This module contains the HttpsMessage class."""
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 from cyhy.mailer.ReportMessage import ReportMessage
@@ -138,9 +138,9 @@ Cybersecurity and Infrastructure Security Agency<br />
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
 
         # Render the templates
-        subject = pystache.render(HttpsMessage.Subject, mustache_data)
-        text_body = pystache.render(HttpsMessage.TextBody, mustache_data)
-        html_body = pystache.render(HttpsMessage.HtmlBody, mustache_data)
+        subject = chevron.render(HttpsMessage.Subject, mustache_data)
+        text_body = chevron.render(HttpsMessage.TextBody, mustache_data)
+        html_body = chevron.render(HttpsMessage.HtmlBody, mustache_data)
 
         ReportMessage.__init__(
             self,

--- a/cyhy/mailer/StatsMessage.py
+++ b/cyhy/mailer/StatsMessage.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 
@@ -100,8 +100,8 @@ Cybersecurity and Infrastructure Security Agency<br>
         }
 
         # Render the templates
-        subject = pystache.render(StatsMessage.Subject, mustache_data)
-        text_body = pystache.render(StatsMessage.TextBody, mustache_data)
-        html_body = pystache.render(StatsMessage.HtmlBody, mustache_data)
+        subject = chevron.render(StatsMessage.Subject, mustache_data)
+        text_body = chevron.render(StatsMessage.TextBody, mustache_data)
+        html_body = chevron.render(StatsMessage.HtmlBody, mustache_data)
 
         Message.__init__(self, to_addrs, subject, text_body, html_body)

--- a/cyhy/mailer/TmailMessage.py
+++ b/cyhy/mailer/TmailMessage.py
@@ -1,6 +1,6 @@
 """This module contains the TmailMessage class."""
 
-import pystache
+import chevron
 
 from cyhy.mailer.Message import Message
 from cyhy.mailer.ReportMessage import ReportMessage
@@ -136,9 +136,9 @@ Cybersecurity and Infrastructure Security Agency<br />
         mustache_data = {"acronym": agency_acronym, "report_date": report_date}
 
         # Render the templates
-        subject = pystache.render(TmailMessage.Subject, mustache_data)
-        text_body = pystache.render(TmailMessage.TextBody, mustache_data)
-        html_body = pystache.render(TmailMessage.HtmlBody, mustache_data)
+        subject = chevron.render(TmailMessage.Subject, mustache_data)
+        text_body = chevron.render(TmailMessage.TextBody, mustache_data)
+        html_body = chevron.render(TmailMessage.HtmlBody, mustache_data)
 
         ReportMessage.__init__(
             self,

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -328,7 +328,7 @@ def send_message(ses_client, message, counter=None, dry_run=False):
             )
             raise UnableToSendError(response)
     else:
-        logging.debug("NOT sending message")
+        logging.debug("NOT sending message (dry run)")
 
     if counter is not None:
         counter += 1

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -1111,7 +1111,7 @@ def main():
     if summary_to and all_stats_strings:
         message = StatsMessage(summary_to.split(","), all_stats_strings)
         try:
-            send_message(ses_client, message, args["--dry-run"])
+            send_message(ses_client, message, dry_run=args["--dry-run"])
         except (UnableToSendError, ClientError):
             logging.error(
                 "Unable to send cyhy-mailer report summary",

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -327,6 +327,8 @@ def send_message(ses_client, message, counter=None, dry_run=False):
                 f"Unable to send message.  Response from boto3 is: {response}"
             )
             raise UnableToSendError(response)
+    else:
+        logging.debug("NOT sending message")
 
     if counter is not None:
         counter += 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.3.14'
+    image: 'dhsncats/cyhy-mailer:1.3.15'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,9 @@ setup(
     packages=["cyhy.mailer"],
     install_requires=[
         "boto3",
+        "chevron",
         "docopt",
         "mongo-db-from-config @ http://github.com/cisagov/mongo-db-from-config/tarball/develop#egg=mongo-db-from-config",
-        "pystache",
     ],
     extras_require={
         "test": ["coveralls", "pre-commit", "pytest", "pytest-cov", "semver"]


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Switches from using [defunkt/pystache](https://github.com/defunkt/pystache) to [noahmorrison/chevron](https://github.com/noahmorrison/chevron).
- Adds a `--dry-run` flag to the CLI that does everything except actually send the emails.

## 💭 Motivation and context ##

- [defunkt/pystache](https://github.com/defunkt/pystache) has not been maintained since 2014 and now fails to install via `pip` on Python 3.9.  [noahmorrison/chevron](https://github.com/noahmorrison/chevron), on the other hand, is a drop-in replacement that _is_ supported.

## 🧪 Testing ##

I used the new `--dry-run` flag to do a full test run for sending the BOD 18-01 reports and verified that [noahmorrison/chevron](https://github.com/noahmorrison/chevron) works great.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.  (It's the end of the month, so our LGTM credits are all used up.)
