### PR TITLE
Pin version of PyMongo to < 4.0

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.4.1"
+__version__ = "1.4.1-rc.1"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.4.1-rc.1"
+__version__ = "1.4.1"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ secrets:
 
 services:
   mailer:
-    image: 'dhsncats/cyhy-mailer:1.4.0'
+    image: 'dhsncats/cyhy-mailer:1.4.1'
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "chevron",
         "docopt",
         "mongo-db-from-config @ http://github.com/cisagov/mongo-db-from-config/tarball/develop#egg=mongo-db-from-config",
+        "pymongo<4.0",
     ],
     extras_require={
         "test": ["coveralls", "pre-commit", "pytest", "pytest-cov", "semver"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR pins the version of PyMongo to less than 4.0.
 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There are several places in the cyhy-mailer CLI code where we call the `pymongo.cursor.Cursor.count()` method.  Since that method was [removed in PyMongo 4.0](https://pymongo.readthedocs.io/en/4.0/changelog.html), we pin to an earlier version until we can make appropriate modifications to our code.  #94 was created to track that issue.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this change by creating a Docker image with this code and pulling it on to one of our reporter instances that had recently been deployed on Debian buster.  I manually updated the composition to use my test Docker image, then started up the composition to [send out cyhy-notifications](https://github.com/cisagov/cyhy-mailer/blob/develop/docker-compose.cyhy-notification.yml), and I confirmed that the process was successful.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Add a tag for `1.4.1`
- [x] Manually build a new `cyhy-mailer:1.4.1` Docker image
- [x] Push `cyhy-mailer:1.4.1` up to DockerHub
- [x] Update `docker-compose.yml` on deployed reporter instance to use `cyhy-mailer:1.4.1`
