### PR TITLE
Include entity name in emails

### DIFF
--- a/cyhy/mailer/CyhyMessage.py
+++ b/cyhy/mailer/CyhyMessage.py
@@ -29,7 +29,7 @@ class CyhyMessage(ReportMessage):
 
     Subject = "{{acronym}} - Cyber Hygiene Report - {{report_date}} Results"
 
-    TextBody = """Greetings {{acronym}},
+    TextBody = """Greetings {{name}} ({{acronym}}),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -57,7 +57,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
     HtmlBody = """<html>
 <head></head>
 <body>
-<p>Greetings {{acronym}},</p>
+<p>Greetings {{name}} ({{acronym}}),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 
@@ -91,6 +91,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         to_addrs,
         pdf_filename,
         entity_acronym,
+        entity_name,
         report_date,
         tech_pocs,
         from_addr=Message.DefaultFrom,
@@ -112,6 +113,10 @@ Cybersecurity and Infrastructure Security Agency<br>
         entity_acronym : str
             The acronym used by the entity corresponding to the CYHY
             report attachment.
+
+        entity_name : str
+            The name of the entity corresponding to the CYHY report
+            attachment.
 
         report_date : str
             The date corresponding to the CYHY report attachment.  We
@@ -140,6 +145,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         # This is the data mustache will use to render the templates
         mustache_data = {
             "acronym": entity_acronym,
+            "name": entity_name,
             "report_date": report_date,
             "has_tech_pocs": len(tech_pocs) != 0,
             "tech_pocs": tech_pocs,

--- a/cyhy/mailer/CyhyMessage.py
+++ b/cyhy/mailer/CyhyMessage.py
@@ -145,9 +145,9 @@ Cybersecurity and Infrastructure Security Agency<br>
         # This is the data mustache will use to render the templates
         mustache_data = {
             "acronym": entity_acronym,
+            "has_tech_pocs": len(tech_pocs) != 0,
             "name": entity_name,
             "report_date": report_date,
-            "has_tech_pocs": len(tech_pocs) != 0,
             "tech_pocs": tech_pocs,
         }
 

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -143,8 +143,8 @@ Cybersecurity and Infrastructure Security Agency<br>
         # This is the data mustache will use to render the templates
         mustache_data = {
             "acronym": entity_acronym,
-            "name": entity_name,
             "is_federal": is_federal,
+            "name": entity_name,
             "report_date": report_date,
         }
 

--- a/cyhy/mailer/CyhyNotificationMessage.py
+++ b/cyhy/mailer/CyhyNotificationMessage.py
@@ -29,7 +29,7 @@ class CyhyNotificationMessage(ReportMessage):
 
     Subject = "{{acronym}} - Cyber Hygiene Alert - {{report_date}}"
 
-    TextBody = """Greetings {{acronym}},
+    TextBody = """Greetings {{name}} ({{acronym}}),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -58,7 +58,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
     HtmlBody = """<html>
 <head></head>
 <body>
-<p>Greetings {{acronym}},</p>
+<p>Greetings {{name}} ({{acronym}}),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -94,6 +94,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         to_addrs,
         pdf_filename,
         entity_acronym,
+        entity_name,
         is_federal,
         report_date,
         from_addr=Message.DefaultFrom,
@@ -115,6 +116,10 @@ Cybersecurity and Infrastructure Security Agency<br>
         entity_acronym : str
             The acronym used by the entity corresponding to the CYHY
             notification attachment.
+
+        entity_name : str
+            The name of the entity corresponding to the CYHY notification
+            attachment.
 
         is_federal : bool
             True if the entity is Federal, otherwise False.
@@ -138,6 +143,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         # This is the data mustache will use to render the templates
         mustache_data = {
             "acronym": entity_acronym,
+            "name": entity_name,
             "is_federal": is_federal,
             "report_date": report_date,
         }

--- a/cyhy/mailer/HttpsMessage.py
+++ b/cyhy/mailer/HttpsMessage.py
@@ -29,7 +29,7 @@ class HttpsMessage(ReportMessage):
 
     Subject = "{{acronym}} - HTTPS Report - {{report_date}} Results"
 
-    TextBody = """Greetings {{acronym}},
+    TextBody = """Greetings {{name}} ({{acronym}}),
 
 Attached is your latest HTTPS Report.
 
@@ -65,7 +65,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings {{acronym}},</p>
+<p>Greetings {{name}} ({{acronym}}),</p>
 <p>Attached is your latest HTTPS Report.</p>
 <p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and CISA <a href="https://cyber.dhs.gov/bod/18-01/">Binding Operational Directive 18-01</a>.</p>
 <p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on {{report_date}}.</b></p>
@@ -98,6 +98,7 @@ Cybersecurity and Infrastructure Security Agency<br />
         to_addrs,
         pdf_filename,
         entity_acronym,
+        entity_name,
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
@@ -119,6 +120,10 @@ Cybersecurity and Infrastructure Security Agency<br />
             The acronym used by the entity corresponding to the
             Trustworthy Email report attachment.
 
+        entity_name : str
+            The name of the entity corresponding to the Trustworthy Email
+            report attachment.
+
         report_date : str
             The date corresponding to the Trustworthy Email report
             attachment.  We have been using dates of the form December
@@ -137,7 +142,11 @@ Cybersecurity and Infrastructure Security Agency<br />
 
         """
         # This is the data mustache will use to render the templates
-        mustache_data = {"acronym": entity_acronym, "report_date": report_date}
+        mustache_data = {
+            "acronym": entity_acronym,
+            "name": entity_name,
+            "report_date": report_date,
+        }
 
         # Render the templates
         subject = chevron.render(HttpsMessage.Subject, mustache_data)

--- a/cyhy/mailer/TmailMessage.py
+++ b/cyhy/mailer/TmailMessage.py
@@ -29,7 +29,7 @@ class TmailMessage(ReportMessage):
 
     Subject = "{{acronym}} - Trustworthy Email Report - {{report_date}} Results"
 
-    TextBody = """Greetings {{acronym}},
+    TextBody = """Greetings {{name}} ({{acronym}}),
 
 Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on {{report_date}}.
 
@@ -63,7 +63,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings {{acronym}},</p>
+<p>Greetings {{name}} ({{acronym}}),</p>
 <p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on {{report_date}}.</b></p>
 <p><a href="https://cyber.dhs.gov/bod/18-01/">CISA Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
 <ul>
@@ -96,6 +96,7 @@ Cybersecurity and Infrastructure Security Agency<br />
         to_addrs,
         pdf_filename,
         entity_acronym,
+        entity_name,
         report_date,
         from_addr=Message.DefaultFrom,
         cc_addrs=Message.DefaultCc,
@@ -117,6 +118,10 @@ Cybersecurity and Infrastructure Security Agency<br />
             The acronym used by the entity corresponding to the
             Trustworthy Email report attachment.
 
+        entity_name : str
+            The name of the entity corresponding to the Trustworthy Email
+            report attachment.
+
         report_date : str
             The date corresponding to the Trustworthy Email report
             attachment.  We have been using dates of the form December
@@ -135,7 +140,11 @@ Cybersecurity and Infrastructure Security Agency<br />
 
         """
         # This is the data mustache will use to render the templates
-        mustache_data = {"acronym": entity_acronym, "report_date": report_date}
+        mustache_data = {
+            "acronym": entity_acronym,
+            "name": entity_name,
+            "report_date": report_date,
+        }
 
         # Render the templates
         subject = chevron.render(TmailMessage.Subject, mustache_data)

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.1-rc.1"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.1-rc.1"
+__version__ = "1.7.1"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -229,6 +229,7 @@ def get_requests_raw(db, query, batch_size=None):
         "agency.contacts.name": True,
         "agency.contacts.type": True,
         "agency.location.state": True,
+        "agency.name": True,
         "agency.type": True,
     }
 
@@ -445,6 +446,7 @@ def send_bod_reports(
     for request in bod_requests:
         id = request["_id"]
         acronym = request["agency"]["acronym"]
+        entity_name = request["agency"]["name"]
 
         to_emails = get_emails_from_request(request)
         # to_emails should contain at least one email
@@ -495,7 +497,11 @@ def send_bod_reports(
 
                 # Construct the Tmail message to send
                 message = TmailMessage(
-                    to_emails, tmail_attachment_filename, acronym, report_date
+                    to_emails,
+                    tmail_attachment_filename,
+                    acronym,
+                    entity_name,
+                    report_date,
                 )
 
                 try:
@@ -551,7 +557,11 @@ def send_bod_reports(
 
                 # Construct the HTTPS message to send
                 message = HttpsMessage(
-                    to_emails, https_attachment_filename, acronym, report_date
+                    to_emails,
+                    https_attachment_filename,
+                    acronym,
+                    entity_name,
+                    report_date,
                 )
 
                 try:
@@ -786,6 +796,7 @@ def send_cyhy_reports(
         for request in cyhy_requests:
             id = request["_id"]
             acronym = request["agency"]["acronym"]
+            entity_name = request["agency"]["name"]
             technical_pocs = [
                 contact
                 for contact in request["agency"]["contacts"]
@@ -871,6 +882,7 @@ def send_cyhy_reports(
                     to_emails,
                     cyhy_attachment_filename,
                     acronym,
+                    entity_name,
                     report_date,
                     technical_pocs,
                     bcc_addrs=bcc_addrs,
@@ -1016,6 +1028,7 @@ def send_cyhy_notifications(
     for request in cyhy_requests:
         id = request["_id"]
         acronym = request["agency"]["acronym"]
+        entity_name = request["agency"]["name"]
         is_federal = id in fed_orgs
 
         to_emails = get_emails_from_request(request)
@@ -1093,6 +1106,7 @@ def send_cyhy_notifications(
                     to_emails,
                     cyhy_notification_attachment_filename,
                     acronym,
+                    entity_name,
                     is_federal,
                     notification_date,
                     bcc_addrs=bcc_addrs,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ secrets:
 
 services:
   mailer:
-    image: cisagov/cyhy-mailer:1.7.0
+    image: cisagov/cyhy-mailer:1.7.1
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cyhymessage.py
+++ b/tests/test_cyhymessage.py
@@ -15,10 +15,13 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
         tech_pocs = []
 
-        message = CyhyMessage(to, pdf, entity_acronym, report_date, tech_pocs)
+        message = CyhyMessage(
+            to, pdf, entity_acronym, entity_name, report_date, tech_pocs
+        )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -39,7 +42,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings CLARKE,
+                text_body = """Greetings Clarke of Kent (CLARKE),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -57,7 +60,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 
@@ -79,13 +82,16 @@ Cybersecurity and Infrastructure Security Agency<br>
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
         tech_pocs = [
             {"name": "Cixin Liu", "email": "cixin@liu.com"},
             {"name": "Alastair Reynolds", "email": "alastair@reynolds.com"},
         ]
 
-        message = CyhyMessage(to, pdf, entity_acronym, report_date, tech_pocs)
+        message = CyhyMessage(
+            to, pdf, entity_acronym, entity_name, report_date, tech_pocs
+        )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -106,7 +112,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings CLARKE,
+                text_body = """Greetings Clarke of Kent (CLARKE),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -134,7 +140,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 
@@ -169,10 +175,13 @@ Cybersecurity and Infrastructure Security Agency<br>
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
         tech_pocs = [{"name": "Cixin Liu", "email": "cixin@liu.com"}]
 
-        message = CyhyMessage(to, pdf, entity_acronym, report_date, tech_pocs)
+        message = CyhyMessage(
+            to, pdf, entity_acronym, entity_name, report_date, tech_pocs
+        )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -193,7 +202,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -218,7 +227,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 
@@ -252,6 +261,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
         tech_pocs = [{"name": "Cixin Liu", "email": "cixin@liu.com"}]
 
@@ -259,6 +269,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             tech_pocs,
             from_addr=fm,
@@ -285,7 +296,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -310,7 +321,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 
@@ -344,6 +355,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
         tech_pocs = [{"name": "Cixin Liu", "email": "cixin@liu.com"}]
 
@@ -351,6 +363,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             tech_pocs,
             from_addr=fm,
@@ -377,7 +390,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)
 
@@ -402,7 +415,7 @@ WARNING: This document is FOR OFFICIAL USE ONLY (FOUO). It contains information 
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 
 <p>The Cyber Hygiene scan results are attached for your review. Same password as before. (If this is your first report and you have yet to receive a password, please let us know.)</p>
 

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -15,11 +15,12 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "FEDTEST"
+        entity_name = "Federal Test"
         is_federal = True
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, entity_acronym, is_federal, report_date
+            to, pdf, entity_acronym, entity_name, is_federal, report_date
         )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
@@ -41,7 +42,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings FEDTEST,
+                text_body = """Greetings Federal Test (FEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -71,7 +72,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings FEDTEST,</p>
+<p>Greetings Federal Test (FEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -108,11 +109,12 @@ Cybersecurity and Infrastructure Security Agency<br>
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "FEDTEST"
+        entity_name = "Federal Test"
         is_federal = True
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, entity_acronym, is_federal, report_date
+            to, pdf, entity_acronym, entity_name, is_federal, report_date
         )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
@@ -134,7 +136,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings FEDTEST,
+                body = """Greetings Federal Test (FEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -164,7 +166,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings FEDTEST,</p>
+<p>Greetings Federal Test (FEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -204,6 +206,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
         entity_acronym = "FEDTEST"
+        entity_name = "Federal Test"
         is_federal = True
         report_date = "December 15, 2001"
 
@@ -211,6 +214,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             is_federal,
             report_date,
             from_addr=fm,
@@ -237,7 +241,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings FEDTEST,
+                body = """Greetings Federal Test (FEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -267,7 +271,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings FEDTEST,</p>
+<p>Greetings Federal Test (FEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -307,6 +311,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
         entity_acronym = "FEDTEST"
+        entity_name = "Federal Test"
         is_federal = True
         report_date = "December 15, 2001"
 
@@ -314,6 +319,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             is_federal,
             report_date,
             from_addr=fm,
@@ -340,7 +346,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings FEDTEST,
+                body = """Greetings Federal Test (FEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -370,7 +376,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings FEDTEST,</p>
+<p>Greetings Federal Test (FEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -407,11 +413,12 @@ Cybersecurity and Infrastructure Security Agency<br>
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "NONFEDTEST"
+        entity_name = "Non-Federal Test"
         is_federal = False
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, entity_acronym, is_federal, report_date
+            to, pdf, entity_acronym, entity_name, is_federal, report_date
         )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
@@ -433,7 +440,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings NONFEDTEST,
+                text_body = """Greetings Non-Federal Test (NONFEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -463,7 +470,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings NONFEDTEST,</p>
+<p>Greetings Non-Federal Test (NONFEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -500,11 +507,12 @@ Cybersecurity and Infrastructure Security Agency<br>
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "NONFEDTEST"
+        entity_name = "Non-Federal Test"
         is_federal = False
         report_date = "December 15, 2001"
 
         message = CyhyNotificationMessage(
-            to, pdf, entity_acronym, is_federal, report_date
+            to, pdf, entity_acronym, entity_name, is_federal, report_date
         )
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
@@ -526,7 +534,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings NONFEDTEST,
+                body = """Greetings Non-Federal Test (NONFEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -556,7 +564,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings NONFEDTEST,</p>
+<p>Greetings Non-Federal Test (NONFEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -596,6 +604,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
         entity_acronym = "NONFEDTEST"
+        entity_name = "Non-Federal Test"
         is_federal = False
         report_date = "December 15, 2001"
 
@@ -603,6 +612,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             is_federal,
             report_date,
             from_addr=fm,
@@ -629,7 +639,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings NONFEDTEST,
+                body = """Greetings Non-Federal Test (NONFEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -659,7 +669,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings NONFEDTEST,</p>
+<p>Greetings Non-Federal Test (NONFEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>
@@ -699,6 +709,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
         entity_acronym = "NONFEDTEST"
+        entity_name = "Non-Federal Test"
         is_federal = False
         report_date = "December 15, 2001"
 
@@ -706,6 +717,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             to,
             pdf,
             entity_acronym,
+            entity_name,
             is_federal,
             report_date,
             from_addr=fm,
@@ -732,7 +744,7 @@ Cybersecurity and Infrastructure Security Agency<br>
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings NONFEDTEST,
+                body = """Greetings Non-Federal Test (NONFEDTEST),
 
 Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 * New critical, high, and/or known exploited vulnerabilities
@@ -762,7 +774,7 @@ WARNING: This message and any attached document(s) is FOR OFFICIAL USE ONLY (FOU
                 html_body = """<html>
 <head></head>
 <body>
-<p>Greetings NONFEDTEST,</p>
+<p>Greetings Non-Federal Test (NONFEDTEST),</p>
 
 <p>Cyber Hygiene scans of your host(s) conducted in the past day have detected one or more of the following:
 <ul>

--- a/tests/test_httpsmessage.py
+++ b/tests/test_httpsmessage.py
@@ -15,9 +15,10 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
-        message = HttpsMessage(to, pdf, entity_acronym, report_date)
+        message = HttpsMessage(to, pdf, entity_acronym, entity_name, report_date)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -37,7 +38,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings CLARKE,
+                text_body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your latest HTTPS Report.
 
@@ -74,7 +75,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your latest HTTPS Report.</p>
 <p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and CISA <a href="https://cyber.dhs.gov/bod/18-01/">Binding Operational Directive 18-01</a>.</p>
 <p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
@@ -108,9 +109,10 @@ Cybersecurity and Infrastructure Security Agency<br />
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
-        message = HttpsMessage(to, pdf, entity_acronym, report_date)
+        message = HttpsMessage(to, pdf, entity_acronym, entity_name, report_date)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -130,7 +132,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your latest HTTPS Report.
 
@@ -167,7 +169,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your latest HTTPS Report.</p>
 <p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and CISA <a href="https://cyber.dhs.gov/bod/18-01/">Binding Operational Directive 18-01</a>.</p>
 <p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
@@ -204,12 +206,14 @@ Cybersecurity and Infrastructure Security Agency<br />
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
         message = HttpsMessage(
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -234,7 +238,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your latest HTTPS Report.
 
@@ -271,7 +275,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your latest HTTPS Report.</p>
 <p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and CISA <a href="https://cyber.dhs.gov/bod/18-01/">Binding Operational Directive 18-01</a>.</p>
 <p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
@@ -308,12 +312,14 @@ Cybersecurity and Infrastructure Security Agency<br />
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
         message = HttpsMessage(
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -338,7 +344,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your latest HTTPS Report.
 
@@ -375,7 +381,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your latest HTTPS Report.</p>
 <p>This report is intended to assist your agency in complying with OMB <a href="https://https.cio.gov">M-15-13</a> and CISA <a href="https://cyber.dhs.gov/bod/18-01/">Binding Operational Directive 18-01</a>.</p>
 <p>This report includes all second-level .gov domains your agency owns and many known subdomains. Subdomains are gleaned from Cyber Hygiene scans, the General Services Administration's <a href="https://analytics.usa.gov/">Digital Analytics Program</a>, <a href=https://censys.io>Censys.io</a>, and data from the <a href="http://eotarchive.cdlib.org/">End of Term Web Archive</a>. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>

--- a/tests/test_tmailmessage.py
+++ b/tests/test_tmailmessage.py
@@ -15,9 +15,10 @@ class Test(unittest.TestCase):
         to = ["recipient@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
-        message = TmailMessage(to, pdf, entity_acronym, report_date)
+        message = TmailMessage(to, pdf, entity_acronym, entity_name, report_date)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -38,7 +39,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                text_body = """Greetings CLARKE,
+                text_body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
 
@@ -73,7 +74,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
 <p><a href="https://cyber.dhs.gov/bod/18-01/">CISA Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
 <ul>
@@ -107,9 +108,10 @@ Cybersecurity and Infrastructure Security Agency<br />
         to = ["recipient@example.com", "recipient2@example.com"]
         pdf = "./tests/data/pdf-sample.pdf"
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
-        message = TmailMessage(to, pdf, entity_acronym, report_date)
+        message = TmailMessage(to, pdf, entity_acronym, entity_name, report_date)
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(
@@ -130,7 +132,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
 
@@ -165,7 +167,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
 <p><a href="https://cyber.dhs.gov/bod/18-01/">CISA Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
 <ul>
@@ -202,12 +204,14 @@ Cybersecurity and Infrastructure Security Agency<br />
         cc = ["cc@example.com"]
         bcc = ["bcc@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
         message = TmailMessage(
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -233,7 +237,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
 
@@ -268,7 +272,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
 <p><a href="https://cyber.dhs.gov/bod/18-01/">CISA Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
 <ul>
@@ -305,12 +309,14 @@ Cybersecurity and Infrastructure Security Agency<br />
         cc = ["cc@example.com", "cc2@example.com"]
         bcc = ["bcc@example.com", "bcc2@example.com"]
         entity_acronym = "CLARKE"
+        entity_name = "Clarke of Kent"
         report_date = "December 15, 2001"
 
         message = TmailMessage(
             to,
             pdf,
             entity_acronym,
+            entity_name,
             report_date,
             from_addr=fm,
             cc_addrs=cc,
@@ -336,7 +342,7 @@ Cybersecurity and Infrastructure Security Agency<br />
                 self.assertEqual(part.get_payload(decode=True), bytes)
                 self.assertEqual(part.get_filename(), "pdf-sample.pdf")
             elif part.get_content_type() == "text/plain":
-                body = """Greetings CLARKE,
+                body = """Greetings Clarke of Kent (CLARKE),
 
 Attached is your Trustworthy Email Report. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a scan that took place on December 15, 2001.
 
@@ -371,7 +377,7 @@ vulnerability@cisa.dhs.gov
 <head></head>
 <body>
 <div style=""font-size:14.5"">
-<p>Greetings CLARKE,</p>
+<p>Greetings Clarke of Kent (CLARKE),</p>
 <p>Attached is your <b>Trustworthy Email Report</b>. This report presents your organization's support of SPF and DMARC, two email authentication standards, as published at your .gov domains. The data in this report comes from a <b>scan that took place on December 15, 2001.</b></p>
 <p><a href="https://cyber.dhs.gov/bod/18-01/">CISA Binding Operational Directive 18-01</a> requires your agency to take certain actions relevant to the data in this report:</p>
 <ul>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR includes the full name of the entity receiving the email is include, rather than just the entity's acronym.  Note that this change applies to the following types of emails:
* CyHy
* CyHy notification
* PSHTT
* Trustymail

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change was requested in #109 to make life easier for the CSAs who receive a large number of these emails.

Resolves #109.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I built a prelease version of this Docker image and pulled it in to the Production reporter and Docker instances.  Then, I ran each type of mailer run (`cyhy`, `notification`, `bod1801`) using the `--dry-run` and `--debug` flags.  `--dry-run` was used so that the emails wouldn't actually be sent out and `--debug` was used so that I could view the contents of the email messages.

Example command:
```console
docker compose up --detach; docker compose logs --follow | grep Greetings
```

Example output before the changes in this PR:
```console
cyhy-mailer-mailer-1  | 2024-04-23 15:30:51,134 DEBUG Message plain-text body: Greetings DHS,
cyhy-mailer-mailer-1  | <p>Greetings DHS,</p>
```

When using my prerelease image with the changes in this PR, I confirmed output like the following:
```console
cyhy-mailer-mailer-1  | 2024-04-23 15:32:54,359 DEBUG Message plain-text body: Greetings Department of Homeland Security (DHS),
cyhy-mailer-mailer-1  | <p>Greetings Department of Homeland Security (DHS),</p>
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.
- [x] Update `docker-compose.yml` to reflect finalized version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Add a tag and create a release.
- [x] Create a local Docker image: `docker build -t cisagov/cyhy-mailer:1.7.1 --platform=linux/amd64 .`
- [x] Push Docker image up to Docker Hub: `docker push cisagov/cyhy-mailer:1.7.1`
- [x] Deploy this change to Production (manual process below) for **both the reporter and Docker instances**:
  - [x] `cd /var/cyhy/cyhy-mailer`
  - [x] Update `docker-compose.yml` to use `cisagov/cyhy-mailer:1.7.1`
  - [x] `docker compose pull`
  - [x] Ensure any `--dry-run` and `--debug` flags (used for testing) in composition files are commented out
