### PR TITLE
Use the `sesv2` `boto3` client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @felddy @jsf9k @mcdonnnj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
-MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
+MAINTAINER Shane Frasier <jeremy.frasier@gwe.cisa.dhs.gov>
 
 # Install shadow so we have adduser and addgroup.  This is a build
 # dependency that will be removed at the end.

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.3-rc.1"
+__version__ = "1.7.3"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.3"
+__version__ = "1.7.3-rc.1"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -320,7 +320,7 @@ def send_message(ses_client, message, counter=None, dry_run=False):
     Parameters
     ----------
     ses_client : boto3.client
-        The boto3 SES client via which the message is to be sent.
+        The boto3 SESv2 client via which the message is to be sent.
 
     message : email.message.Message
         The email message that is to be sent.
@@ -349,7 +349,7 @@ def send_message(ses_client, message, counter=None, dry_run=False):
     if not dry_run:
         # "Are you silly?  I'm still gonna send it!"
         #   -- Larry Enticer
-        response = ses_client.send_raw_email(RawMessage={"Data": message.as_string()})
+        response = ses_client.send_email(Content={"Raw": {"Data": message.as_string()}})
 
         # Check for errors
         status_code = response["ResponseMetadata"]["HTTPStatusCode"]
@@ -383,7 +383,7 @@ def send_bod_reports(
         database.  If None then the default will be used.
 
     ses_client : boto3.client
-        The boto3 SES client via which the message is to be sent.
+        The boto3 SESv2 client via which the message is to be sent.
 
     tmail_report_dir : str
         The directory where the Trustworthy Email reports can be
@@ -602,7 +602,7 @@ def send_cybex_scorecard(
         database.  If None then the default will be used.
 
     ses_client : boto3.client
-        The boto3 SES client via which the message is to be sent.
+        The boto3 SESv2 client via which the message is to be sent.
 
     cybex_scorecard_dir : str
         The directory where the Cybex scorecard can be found.  If None
@@ -750,7 +750,7 @@ def send_cyhy_reports(
         database.  If None then the default will be used.
 
     ses_client : boto3.client
-        The boto3 SES client via which the message is to be sent.
+        The boto3 SESv2 client via which the message is to be sent.
 
     cyhy_report_dir : str
         The directory where the Cyber Hygiene reports can be found.
@@ -981,7 +981,7 @@ def send_cyhy_notifications(
         database.  If None then the default will be used.
 
     ses_client : boto3.client
-        The boto3 SES client via which the message is to be sent.
+        The boto3 SESv2 client via which the message is to be sent.
 
     cyhy_notification_dir : str
         The directory where the Cyber Hygiene notifications can be found.
@@ -1208,7 +1208,7 @@ def main():
         # The user doesn't want to BCC the CSAs.
         csa_emails = None
 
-    ses_client = boto3.client("ses")
+    ses_client = boto3.client("sesv2")
 
     batch_size = args["--batch-size"]
     if batch_size is not None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ secrets:
 
 services:
   mailer:
-    image: cisagov/cyhy-mailer:1.7.2
+    image: cisagov/cyhy-mailer:1.7.3-rc.1
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 ---
-# The version for the main docker-compose configuration needs to be
-# the lowest version that supports the features used by all
-# docker-compose configurations in this project. This is to support
-# the use of a 'docker-compose.override.yml' file derived from one of
-# the other configurations as documented here:
-# https://docs.docker.com/compose/extends/#multiple-compose-files
-version: '3.2'
-
 secrets:
   database_creds:
     file: ./secrets/database_creds.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ secrets:
 
 services:
   mailer:
-    image: cisagov/cyhy-mailer:1.7.3-rc.1
+    image: cisagov/cyhy-mailer:1.7.3
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the code to use the `sesv2` `boto3` client.

## 💭 Motivation and context ##

The SESv2 AWS API is [the way forward](https://aws.amazon.com/blogs/messaging-and-targeting/upgrade-your-email-tech-stack-with-amazon-sesv2-api/).  New features are only supported in the SESv2 API.

## 🧪 Testing ##

All `pytest` tests pass.  I tested these changes by sending the BOD reports to myself.

I also verified that the messages sent by `cyhy-mailer` are now showing up in the AWS SES Virtual Deliverability Manager.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.
- [x] Update `docker-compose.yml` to use `cisagov/cyhy-mailer:1.7.3`.

## ✅ Post-merge checklist ##

- [x] Create a release.
- [x] Build and push `cisagov/cyhy-mailer:1.7.3`.
- [x] Manually update the `docker-compose.yml` file on `reporter.prod-a.cyhy` and `docker.prod-a.bod` to use `cisagov/cyhy-mailer:1.7.3`.
