### PR TITLE
Remove deprecated version key in Docker composition files

### DIFF
--- a/docker-compose.bod.yml
+++ b/docker-compose.bod.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.2'
-
 services:
   mailer:
     volumes:

--- a/docker-compose.cyhy-notification.yml
+++ b/docker-compose.cyhy-notification.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.2'
-
 secrets:
   csa_emails:
     file: ./secrets/csa_emails.yml

--- a/docker-compose.cyhy.yml
+++ b/docker-compose.cyhy.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.2'
-
 secrets:
   csa_emails:
     file: ./secrets/csa_emails.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes deprecated `version` keys from all Docker composition files.

## 💭 Motivation and context ##

These files should have been updated along with docker-compose.yml in commit 759a6987ae2adb6c7757e5f74eb69e815e59c8f6 of #113, but I neglected to do that.

## 🧪 Testing ##

Docker ignores this key now, so this change should make no difference.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).