### PR TITLE
Remove `cyhy_reports@hq.dhs.gov` email address everywhere

### DIFF
--- a/cyhy/mailer/CybexMessage.py
+++ b/cyhy/mailer/CybexMessage.py
@@ -32,7 +32,6 @@ class CybexMessage(ReportMessage):
     """
 
     DefaultTo = [
-        "CyHy_Reports@hq.dhs.gov",
         "CyberDirectives@cisa.dhs.gov",
         "CyberLiaison@cisa.dhs.gov",
         "cyberscopehelp@cisa.dhs.gov",

--- a/cyhy/mailer/Message.py
+++ b/cyhy/mailer/Message.py
@@ -36,7 +36,9 @@ class Message(MIMEMultipart):
 
     DefaultCc = None
 
-    DefaultBcc = ["cyhy_reports@hq.dhs.gov"]
+    # With an empty list, this type annotation is necessary for the mypy
+    # pre-commit linter that is run on this code.
+    DefaultBcc: list[str] = []
 
     DefaultReplyTo = "vulnerability@cisa.dhs.gov"
 

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ secrets:
 
 services:
   mailer:
-    image: cisagov/cyhy-mailer:1.7.3
+    image: cisagov/cyhy-mailer:1.7.4
     secrets:
       - source: database_creds
         target: database_creds.yml

--- a/tests/test_cybexmessage.py
+++ b/tests/test_cybexmessage.py
@@ -23,10 +23,10 @@ class Test(unittest.TestCase):
             message["Subject"], "Cyber Exposure Scorecard - December 15, 2001 Results"
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(
             message["To"],
-            "CyHy_Reports@hq.dhs.gov,CyberDirectives@cisa.dhs.gov,CyberLiaison@cisa.dhs.gov,cyberscopehelp@cisa.dhs.gov",
+            "CyberDirectives@cisa.dhs.gov,CyberLiaison@cisa.dhs.gov,cyberscopehelp@cisa.dhs.gov",
         )
 
         # Grab the bytes that comprise the attachments

--- a/tests/test_cyhymessage.py
+++ b/tests/test_cyhymessage.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -103,7 +103,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -197,7 +197,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             "CLARKE - Cyber Hygiene Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_cyhynotificationmessage.py
+++ b/tests/test_cyhynotificationmessage.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
             "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -123,7 +123,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             "FEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -427,7 +427,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -521,7 +521,7 @@ Cybersecurity and Infrastructure Security Agency<br>
             "NONFEDTEST - Cyber Hygiene Alert - December 15, 2001",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_httpsmessage.py
+++ b/tests/test_httpsmessage.py
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -119,7 +119,7 @@ Cybersecurity and Infrastructure Security Agency<br />
             message["Subject"], "CLARKE - HTTPS Report - December 15, 2001 Results"
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
     def test_one_param_multiple_recipients(self):
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
     def test_six_params_single_cc(self):

--- a/tests/test_reportmessage.py
+++ b/tests/test_reportmessage.py
@@ -23,7 +23,7 @@ class Test(unittest.TestCase):
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], subject)
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment

--- a/tests/test_statsmessage.py
+++ b/tests/test_statsmessage.py
@@ -22,7 +22,7 @@ class Test(unittest.TestCase):
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], "cyhy-mailer summary from {}".format(date))
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Make sure the correct body and PDF attachments were added
@@ -88,7 +88,7 @@ Cybersecurity and Infrastructure Security Agency<br>
         self.assertEqual(message["From"], "reports@cyber.dhs.gov")
         self.assertEqual(message["Subject"], "cyhy-mailer summary from {}".format(date))
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Make sure the correct body and PDF attachments were added

--- a/tests/test_tmailmessage.py
+++ b/tests/test_tmailmessage.py
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com")
 
         # Grab the bytes that comprise the attachment
@@ -119,7 +119,7 @@ Cybersecurity and Infrastructure Security Agency<br />
             "CLARKE - Trustworthy Email Report - December 15, 2001 Results",
         )
         self.assertEqual(message.get("CC"), None)
-        self.assertEqual(message["BCC"], "cyhy_reports@hq.dhs.gov")
+        self.assertEqual(message["BCC"], None)
         self.assertEqual(message["To"], "recipient@example.com,recipient2@example.com")
 
         # Grab the bytes that comprise the attachment


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the `cyhy_reports@hq.dhs.gov` email address from this repository.

## 💭 Motivation and context ##

Resolves #115.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass. (I verified this manually by running `pytest`.)

## ✅ Pre-merge checklist ##

- [x] Build a new `cisagov/cyhy-mailer` Docker image with these changes.

## ✅ Post-merge checklist ##

- [x] Create a release.
- [x] Manually push these changes to the CyHy `reporter` and BOD `docker` instances in the Cyber Hygiene environment.
