### PR TITLE
Output org's enrollment date when a CyHy report cannot be found

### DIFF
--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.5"
+__version__ = "1.7.5-rc.1"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.5-rc.1"
+__version__ = "1.7.5"

--- a/cyhy/mailer/__init__.py
+++ b/cyhy/mailer/__init__.py
@@ -1,3 +1,3 @@
 """This package contains the cyhy-mailer code."""
 
-__version__ = "1.7.4"
+__version__ = "1.7.5"

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -231,6 +231,7 @@ def get_requests_raw(db, query, batch_size=None):
         "agency.location.state": True,
         "agency.name": True,
         "agency.type": True,
+        "enrolled": True,
     }
 
     try:
@@ -796,6 +797,7 @@ def send_cyhy_reports(
         for request in cyhy_requests:
             id = request["_id"]
             acronym = request["agency"]["acronym"]
+            enrolled = request["enrolled"]
             entity_name = request["agency"]["name"]
             technical_pocs = [
                 contact
@@ -856,7 +858,9 @@ def send_cyhy_reports(
                 # doc has "CYHY_THIRD_PARTY" in its report_types, but
                 # it does not have any children (the reporting code
                 # skips these request docs).
-                logging.error(f"No Cyber Hygiene report found for entity with ID {id}")
+                logging.error(
+                    f"No Cyber Hygiene report found for entity with ID {id} and enrollment date {enrolled}"
+                )
 
             if cyhy_report_filenames:
                 # We take the last filename since, if there happens to be more

--- a/cyhy/mailer/cli.py
+++ b/cyhy/mailer/cli.py
@@ -797,7 +797,7 @@ def send_cyhy_reports(
         for request in cyhy_requests:
             id = request["_id"]
             acronym = request["agency"]["acronym"]
-            enrolled = request["enrolled"]
+            enrolled = request.get("enrolled", "n/a")
             entity_name = request["agency"]["name"]
             technical_pocs = [
                 contact

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ secrets:
 
 services:
   mailer:
-    image: cisagov/cyhy-mailer:1.7.4
+    image: cisagov/cyhy-mailer:1.7.5
     secrets:
       - source: database_creds
         target: database_creds.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Python code to output an org's enrollment date when a corresponding CyHy report cannot be found.

## 💭 Motivation and context ##

This output is useful when sending the CyHy reports, since it allows one to quickly determine if a CyHy report is "missing" just because the corresponding org was created after reporting was kicked off.

This addition was suggested by @dav3r.

## 🧪 Testing ##

- I ran the `pytest` tests locally and verified that they all still pass.
- I built a release candidate Docker image, re-ran the CyHy reporting with the `--dry-run` flag in place, and verified that the output of `cyhy-mailer` showed the enrollment date for orgs that lacked an actual CyHy report.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release.
- [x] Create and push version 1.7.5 of the Docker image.
